### PR TITLE
Filtros por servicios en el renderizado condicional por providerId

### DIFF
--- a/src/app/pages/dashboard/comments/Comments.jsx
+++ b/src/app/pages/dashboard/comments/Comments.jsx
@@ -27,7 +27,7 @@ const Comments = () => {
 
   const { isLoading: serviceLoading, data: serviceData } = useQuery(
     ["getAllService"],
-    () => CommentsServices.getAllService()
+    () => providerId ? CommentsServices.getAllService(providerId) : CommentsServices.getAllService()
   );
 
   const handleChangeFilters = async (e) => {
@@ -125,7 +125,15 @@ const Comments = () => {
                   onChange={handleChangeService}
                 >
                   <option hidden>Servicio</option>
-                  {
+                  {providerId ? (
+                    serviceData?.data[0]?.provider_assign_service?.map((servicio, index) => (
+                      <option
+                        key={index}
+                        value={servicio.service.id}
+                      >{servicio.service.name}
+                      </option>
+                    ))
+                  ) :
                     serviceData?.data?.map((ser, index) => (
                       <option
                         key={index}

--- a/src/app/services/dashboard/comments/comments.services.js
+++ b/src/app/services/dashboard/comments/comments.services.js
@@ -24,7 +24,7 @@ const CommentsServices = {
       return await HttpRequest.get(url)
     }
   },
-  getAllService: async () => await HttpRequest.get(`/service`),
+  getAllService: async (ProviderId) => await HttpRequest.get(ProviderId ? `/service/provider/${ProviderId}`: `/service`),
 };
 
 export default CommentsServices;


### PR DESCRIPTION
Ahora se pueden agregar servicios personalizados para que se muestren en el filtro de cada proveedor de acuerdo a la ruta dinámica